### PR TITLE
Add story creation UI

### DIFF
--- a/taletinker/settings.py
+++ b/taletinker/settings.py
@@ -63,7 +63,7 @@ ROOT_URLCONF = 'taletinker.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
+        'DIRS': [BASE_DIR / 'taletinker' / 'templates'],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [

--- a/taletinker/stories/forms.py
+++ b/taletinker/stories/forms.py
@@ -1,0 +1,78 @@
+from django import forms
+
+THEME_CHOICES = [
+    ("family", "Family"),
+    ("friendship", "Friendship"),
+    ("nature", "Nature"),
+    ("animals", "Animals"),
+    ("courage", "Courage"),
+    ("technology", "Technology"),
+]
+
+PURPOSE_CHOICES = [
+    ("joyful", "Joyful"),
+    ("soothing", "Soothing"),
+    ("support", "Supportive"),
+]
+
+LANGUAGE_CHOICES = [
+    ("en", "English"),
+    ("es", "Spanish"),
+    ("fr", "French"),
+    ("de", "German"),
+]
+
+LENGTH_CHOICES = [
+    ("short", "Short"),
+    ("medium", "Medium"),
+    ("long", "Long"),
+]
+
+
+class StoryCreationForm(forms.Form):
+    realism = forms.IntegerField(
+        min_value=0,
+        max_value=100,
+        initial=50,
+        widget=forms.NumberInput(attrs={"type": "range"}),
+        label="Realistic ↔ Fantastic",
+    )
+
+    didactic = forms.IntegerField(
+        min_value=0,
+        max_value=100,
+        initial=50,
+        widget=forms.NumberInput(attrs={"type": "range"}),
+        label="Didactic ↔ Fun",
+    )
+
+    age = forms.IntegerField(
+        min_value=3,
+        max_value=10,
+        initial=5,
+        widget=forms.NumberInput(attrs={"type": "range", "step": 1}),
+        label="Target Age",
+    )
+
+    themes = forms.MultipleChoiceField(
+        choices=THEME_CHOICES,
+        required=False,
+        widget=forms.CheckboxSelectMultiple,
+    )
+
+    purposes = forms.MultipleChoiceField(
+        choices=PURPOSE_CHOICES,
+        required=False,
+        widget=forms.CheckboxSelectMultiple,
+        label="Purpose",
+    )
+
+    characters = forms.CharField(required=False, label="Characters")
+    extra_instructions = forms.CharField(
+        widget=forms.Textarea,
+        required=False,
+        label="Extra Instructions",
+    )
+
+    story_length = forms.ChoiceField(choices=LENGTH_CHOICES, label="Story Length")
+    language = forms.ChoiceField(choices=LANGUAGE_CHOICES)

--- a/taletinker/stories/templates/stories/create_story.html
+++ b/taletinker/stories/templates/stories/create_story.html
@@ -1,0 +1,83 @@
+{% extends "base.html" %}
+{% load static %}
+{% block title %}Create Story{% endblock %}
+{% block extra_head %}
+<script>
+function toggleChip(el) {
+  const input = el.querySelector('input');
+  input.checked = !input.checked;
+  if (input.checked) {
+    el.classList.add('selected');
+  } else {
+    el.classList.remove('selected');
+  }
+}
+window.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('.chip').forEach(chip => {
+    chip.addEventListener('click', () => toggleChip(chip));
+  });
+  document.querySelectorAll('.example-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const text = btn.dataset.text;
+      document.getElementById('id_extra_instructions').value = text;
+    });
+  });
+});
+</script>
+{% endblock %}
+{% block content %}
+<form method="post">
+  {% csrf_token %}
+  <div class="form-group">
+    {{ form.realism.label_tag }}<br>
+    {{ form.realism }}
+  </div>
+  <div class="form-group">
+    {{ form.didactic.label_tag }}<br>
+    {{ form.didactic }}
+  </div>
+  <div class="form-group">
+    {{ form.age.label_tag }} (3–10+)<br>
+    {{ form.age }}
+  </div>
+  <div class="form-group">
+    <label>Themes</label>
+    <div class="chips">
+      {% for checkbox in form.themes %}
+      <div class="chip">{{ checkbox }} {{ checkbox.choice_label }}</div>
+      {% endfor %}
+    </div>
+  </div>
+  <div class="form-group">
+    <label>Purpose</label>
+    <div class="chips">
+      {% for checkbox in form.purposes %}
+      <div class="chip">{{ checkbox }} {{ checkbox.choice_label }}</div>
+      {% endfor %}
+    </div>
+  </div>
+  <div class="form-group">
+    {{ form.characters.label_tag }}
+    {{ form.characters }}
+  </div>
+  <div class="form-group">
+    {{ form.extra_instructions.label_tag }}
+    {{ form.extra_instructions }}
+  </div>
+  <div class="form-group">
+    {{ form.story_length.label_tag }}
+    {{ form.story_length }}
+  </div>
+  <div class="form-group">
+    {{ form.language.label_tag }}
+    {{ form.language }}
+  </div>
+  <button type="submit">Generate Story</button>
+</form>
+<div class="form-group examples">
+  <strong>Inspire me:</strong>
+  <button type="button" class="example-btn" data-text="A shy dragon finding its roar.">Shy dragon finds roar</button>
+  <button type="button" class="example-btn" data-text="Robots learning to share toys.">Robots share toys</button>
+  <button type="button" class="example-btn" data-text="A magical forest picnic adventure.">Forest picnic</button>
+</div>
+{% endblock %}

--- a/taletinker/stories/tests.py
+++ b/taletinker/stories/tests.py
@@ -1,3 +1,10 @@
-from django.test import TestCase
+from django.test import Client, TestCase
+from django.urls import reverse
 
-# Create your tests here.
+
+class CreateStoryViewTests(TestCase):
+    def test_get_create_page(self):
+        client = Client()
+        response = client.get(reverse("create_story"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Generate Story")

--- a/taletinker/stories/views.py
+++ b/taletinker/stories/views.py
@@ -1,3 +1,8 @@
 from django.shortcuts import render
 
-# Create your views here.
+from .forms import StoryCreationForm
+
+
+def create_story(request):
+    form = StoryCreationForm()
+    return render(request, "stories/create_story.html", {"form": form})

--- a/taletinker/templates/base.html
+++ b/taletinker/templates/base.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}TaleTinker{% endblock %}</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 1rem auto; max-width: 800px; padding: 0 1rem; }
+        .form-group { margin-bottom: 1rem; }
+        label { display: block; margin-bottom: 0.5rem; }
+        input[type=range] { width: 100%; }
+        .chips { display: flex; flex-wrap: wrap; gap: 0.5rem; margin: 0.5rem 0; }
+        .chip { padding: 0.25rem 0.75rem; border: 1px solid #999; border-radius: 16px; cursor: pointer; }
+        .chip input { display: none; }
+        .chip.selected { background-color: #ddd; }
+        .examples button { margin-right: 0.5rem; }
+    </style>
+    {% block extra_head %}{% endblock %}
+</head>
+<body>
+    <h1><a href="/">TaleTinker</a></h1>
+    {% block content %}{% endblock %}
+</body>
+</html>

--- a/taletinker/urls.py
+++ b/taletinker/urls.py
@@ -17,6 +17,9 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path
 
+from taletinker.stories.views import create_story
+
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('create/', create_story, name='create_story'),
 ]


### PR DESCRIPTION
## Summary
- implement minimal story creation page at `/create`
- include sliders, multi-select chips, and example buttons
- wire up form and template
- add view, URL route, and tests
- load templates from project-level directory

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_b_68545badcbd88328bd6ea2f81e3cb501