### PR TITLE
Add async story generation

### DIFF
--- a/taletinker/stories/templates/stories/create_story.html
+++ b/taletinker/stories/templates/stories/create_story.html
@@ -2,6 +2,9 @@
 {% load static %}
 {% block title %}Create Story{% endblock %}
 {% block extra_head %}
+<style>
+  #spinner { display: none; margin: 1rem 0; font-weight: bold; }
+</style>
 <script>
 function toggleChip(el) {
   const input = el.querySelector('input');
@@ -13,6 +16,8 @@ function toggleChip(el) {
   }
 }
 window.addEventListener('DOMContentLoaded', () => {
+  const form = document.querySelector('form');
+  const spinner = document.getElementById('spinner');
   document.querySelectorAll('.chip').forEach(chip => {
     chip.addEventListener('click', () => toggleChip(chip));
   });
@@ -22,12 +27,47 @@ window.addEventListener('DOMContentLoaded', () => {
       document.getElementById('id_extra_instructions').value = text;
     });
   });
+
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    spinner.style.display = 'block';
+
+    const data = {
+      realism: parseInt(form.realism.value),
+      didactic: parseInt(form.didactic.value),
+      age: parseInt(form.age.value),
+      themes: Array.from(form.querySelectorAll('input[name="themes"]:checked')).map(el => el.value),
+      purposes: Array.from(form.querySelectorAll('input[name="purposes"]:checked')).map(el => el.value),
+      characters: form.characters.value,
+      extra_instructions: form.extra_instructions.value,
+      story_length: form.story_length.value,
+      language: form.language.value,
+    };
+
+    try {
+      const resp = await fetch('/api/create', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+      const json = await resp.json();
+      form.story_text.value = json.story;
+    } catch (err) {
+      console.error(err);
+      spinner.style.display = 'none';
+      return;
+    }
+
+    spinner.style.display = 'none';
+    form.submit();
+  });
 });
 </script>
 {% endblock %}
 {% block content %}
 <form method="post">
   {% csrf_token %}
+  <input type="hidden" name="story_text" id="story_text" />
   <div class="form-group">
     {{ form.realism.label_tag }}<br>
     {{ form.realism }}
@@ -73,6 +113,7 @@ window.addEventListener('DOMContentLoaded', () => {
     {{ form.language }}
   </div>
   <button type="submit">Generate Story</button>
+  <div id="spinner">Generating...</div>
 </form>
 <div class="form-group examples">
   <strong>Inspire me:</strong>

--- a/taletinker/stories/tests.py
+++ b/taletinker/stories/tests.py
@@ -30,6 +30,7 @@ class CreateStoryViewTests(TestCase):
             "extra_instructions": "A test story.",
             "story_length": "short",
             "language": "en",
+            "story_text": "Once upon a time",
         }
         response = self.client.post(reverse("create_story"), data)
         self.assertEqual(response.status_code, 302)
@@ -37,6 +38,7 @@ class CreateStoryViewTests(TestCase):
         story = Story.objects.first()
         self.assertEqual(story.author, self.user)
         self.assertEqual(story.parameters["realism"], 50)
+        self.assertEqual(story.texts.first().text, "Once upon a time")
 
 
 class NinjaCreateApiTests(TestCase):

--- a/taletinker/stories/views.py
+++ b/taletinker/stories/views.py
@@ -2,7 +2,7 @@ from django.contrib.auth.decorators import login_required
 from django.shortcuts import redirect, render
 
 from .forms import StoryCreationForm
-from .models import Story
+from .models import Story, StoryText
 
 
 @login_required
@@ -10,7 +10,7 @@ def create_story(request):
     if request.method == "POST":
         form = StoryCreationForm(request.POST)
         if form.is_valid():
-            Story.objects.create(
+            story = Story.objects.create(
                 author=request.user,
                 parameters={
                     "realism": form.cleaned_data["realism"],
@@ -24,6 +24,14 @@ def create_story(request):
                 prompt=form.cleaned_data["extra_instructions"],
                 original_language=form.cleaned_data["language"],
             )
+            text = request.POST.get("story_text")
+            if text:
+                StoryText.objects.create(
+                    story=story,
+                    language=form.cleaned_data["language"],
+                    title=text.splitlines()[0][:255] if text.strip() else "Story",
+                    text=text,
+                )
             return redirect("create_story")
     else:
         form = StoryCreationForm()


### PR DESCRIPTION
## Summary
- create StoryText on submit and intercept form submission via JS
- show a spinner while requesting `/api/create`
- add tests for StoryText save

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_b_6855149e06ac8328bf7cf99216ee0776