### PR TITLE
Add structured OpenAI output

### DIFF
--- a/taletinker/stories/templates/stories/create_story.html
+++ b/taletinker/stories/templates/stories/create_story.html
@@ -51,7 +51,8 @@ window.addEventListener('DOMContentLoaded', () => {
         body: JSON.stringify(data),
       });
       const json = await resp.json();
-      form.story_text.value = json.story;
+      form.story_text.value = json.text;
+      document.getElementById('story_title').value = json.title;
     } catch (err) {
       console.error(err);
       spinner.style.display = 'none';
@@ -68,6 +69,7 @@ window.addEventListener('DOMContentLoaded', () => {
 <form method="post">
   {% csrf_token %}
   <input type="hidden" name="story_text" id="story_text" />
+  <input type="hidden" name="story_title" id="story_title" />
   <div class="form-group">
     {{ form.realism.label_tag }}<br>
     {{ form.realism }}

--- a/taletinker/stories/tests.py
+++ b/taletinker/stories/tests.py
@@ -31,6 +31,7 @@ class CreateStoryViewTests(TestCase):
             "story_length": "short",
             "language": "en",
             "story_text": "Once upon a time",
+            "story_title": "My Story",
         }
         response = self.client.post(reverse("create_story"), data)
         self.assertEqual(response.status_code, 302)
@@ -39,6 +40,7 @@ class CreateStoryViewTests(TestCase):
         self.assertEqual(story.author, self.user)
         self.assertEqual(story.parameters["realism"], 50)
         self.assertEqual(story.texts.first().text, "Once upon a time")
+        self.assertEqual(story.texts.first().title, "My Story")
 
     def test_post_redirects_to_detail(self):
         self.client.force_login(self.user)
@@ -53,6 +55,7 @@ class CreateStoryViewTests(TestCase):
             "story_length": "short",
             "language": "en",
             "story_text": "Once upon a time",
+            "story_title": "My Story",
         }
         response = self.client.post(reverse("create_story"), data)
         story = Story.objects.first()
@@ -67,7 +70,13 @@ class NinjaCreateApiTests(TestCase):
     def test_post_returns_story_text(self, mock_openai):
         mock_client = mock_openai.return_value
         mock_client.chat.completions.create.return_value = SimpleNamespace(
-            choices=[SimpleNamespace(message=SimpleNamespace(content="Hello"))]
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(
+                        content='{"title": "Hi", "text": "Hello"}'
+                    )
+                )
+            ]
         )
 
         response = self.client.post(
@@ -81,5 +90,6 @@ class NinjaCreateApiTests(TestCase):
             content_type="application/json",
         )
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json()["story"], "Hello")
+        self.assertEqual(response.json()["title"], "Hi")
+        self.assertEqual(response.json()["text"], "Hello")
 

--- a/taletinker/stories/views.py
+++ b/taletinker/stories/views.py
@@ -25,11 +25,12 @@ def create_story(request):
                 original_language=form.cleaned_data["language"],
             )
             text = request.POST.get("story_text")
+            title = request.POST.get("story_title")
             if text:
                 StoryText.objects.create(
                     story=story,
                     language=form.cleaned_data["language"],
-                    title=text.splitlines()[0][:255] if text.strip() else "Story",
+                    title=title or (text.splitlines()[0][:255] if text.strip() else "Story"),
                     text=text,
                 )
             return redirect("story_detail", story_id=story.id)


### PR DESCRIPTION
## Summary
- instruct OpenAI to respond with JSON containing `title` and `text`
- parse JSON result in the API and return it
- store `story_title` from hidden form field in `StoryText`
- update JS to handle new API output
- adjust tests for structured responses

## Testing
- `python manage.py test -v 1`

------
https://chatgpt.com/codex/tasks/task_b_6855189458b88328933d37e0ee5d76b2