### PR TITLE
Add StoryImage API endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .*
 __pycache__/
 db.sqlite3
+images/
+thumbs/

--- a/taletinker/stories/templates/stories/story_detail.html
+++ b/taletinker/stories/templates/stories/story_detail.html
@@ -2,6 +2,9 @@
 {% block title %}Story Detail{% endblock %}
 {% block content %}
 <h2>{{ story.texts.first.title }}</h2>
+{% if story.images.first %}
+  <img src="{{ story.images.first.image.url }}" class="img-fluid mb-3" alt="Cover image" />
+{% endif %}
 <p>
   <span
     class="like-btn"


### PR DESCRIPTION
## Summary
- add new `/create_image` endpoint to generate StoryImage and save it
- show the first story image on detail page
- cover the new endpoint and template logic with tests
- ignore generated media directories

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_b_6855346c47d0832880ca83960953157f