### PR TITLE
Add async audio generation

### DIFF
--- a/taletinker/stories/templates/stories/story_detail.html
+++ b/taletinker/stories/templates/stories/story_detail.html
@@ -30,6 +30,25 @@
     {% endif %}
 
     <p>{{ story.texts.first.text|linebreaks }}</p>
+
+    {% if story.audios.first %}
+      <div id="audio-container" class="my-3">
+        <audio id="story-audio" controls>
+          <source src="{{ story.audios.first.mp3.url }}" type="audio/mpeg" />
+        </audio>
+      </div>
+    {% else %}
+      <p id="audio-status">Creating audio...</p>
+      <script>
+        document.addEventListener('DOMContentLoaded', () => {
+          fetch('/api/create_audio', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ story_id: {{ story.id }} })
+          }).then(resp => { if (resp.ok) location.reload(); });
+        });
+      </script>
+    {% endif %}
 </div>
 
 <div style="clear: both;"></div>

--- a/taletinker/stories/tests.py
+++ b/taletinker/stories/tests.py
@@ -268,4 +268,19 @@ class ImageCreationFlowTests(TestCase):
         }
         resp = self.client.post(reverse("create_story"), data, follow=True)
         self.assertContains(resp, "Creating image...")
+        self.assertContains(resp, "Creating audio...")
+
+
+class StoryAudioDisplayTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="aud", password="pass")
+        self.client = Client()
+
+    def test_detail_shows_audio(self):
+        story = Story.objects.create(author=self.user, is_published=True)
+        story.texts.create(language="en", title="T", text="x")
+        story.audios.create(mp3=ContentFile(b"mp3", name="a.mp3"), language="en")
+
+        resp = self.client.get(reverse("story_detail", args=[story.id]))
+        self.assertContains(resp, "<audio")
 


### PR DESCRIPTION
## Summary
- generate narration audio if missing when viewing a story
- show a play button after narration is created
- cover tests for audio creation flow and audio display

## Testing
- `python manage.py test taletinker.stories -v 2`

------
https://chatgpt.com/codex/tasks/task_b_68554dc46cd883289ab772633a7fe5e4