### PR TITLE
Display story list with image cards

### DIFF
--- a/taletinker/stories/templates/stories/story_list.html
+++ b/taletinker/stories/templates/stories/story_list.html
@@ -3,29 +3,35 @@
 {% block content %}
 <h2>Stories</h2>
 {% if stories %}
-<ul class="list-group">
+<div class="row row-cols-1 row-cols-md-3 g-4">
   {% for story in stories %}
-  <li class="list-group-item d-flex justify-content-between align-items-center">
-    <div>
-      <a href="{% url 'story_detail' story.id %}">{{ story.texts.first.title }}</a>
-      <small class="text-muted">
-      {% if story.is_anonymous %}
-        by Anonymous
-      {% else %}
-        by {{ story.author.username }}
-      {% endif %}
-      </small>
+  <div class="col">
+    <div class="card h-100">
+      {% with img=story.images.first %}
+        {% if img %}
+          <img src="{{ img.thumbnail.url }}" class="card-img-top" alt="Cover image" />
+        {% endif %}
+      {% endwith %}
+      <div class="card-body">
+        <h5 class="card-title"><a href="{% url 'story_detail' story.id %}">{{ story.texts.first.title }}</a></h5>
+        <p class="card-text">
+          <small class="text-muted">
+          {% if story.is_anonymous %}
+            by Anonymous
+          {% else %}
+            by {{ story.author.username }}
+          {% endif %}
+          </small>
+        </p>
+      </div>
+      <div class="card-footer d-flex justify-content-between align-items-center">
+        <span class="like-btn" data-story-id="{{ story.id }}">{% if user.is_authenticated and user in story.liked_by.all %}★{% else %}☆{% endif %}</span>
+        <span class="like-count">{{ story.liked_by.count }}</span>
+      </div>
     </div>
-    <div>
-      <span
-        class="like-btn"
-        data-story-id="{{ story.id }}"
-      >{% if user.is_authenticated and user in story.liked_by.all %}★{% else %}☆{% endif %}</span>
-      <span class="like-count">{{ story.liked_by.count }}</span>
-    </div>
-  </li>
+  </div>
   {% endfor %}
-</ul>
+</div>
 {% else %}
 <p>No stories yet.</p>
 {% endif %}

--- a/taletinker/stories/tests.py
+++ b/taletinker/stories/tests.py
@@ -245,6 +245,14 @@ class StoryImageDisplayTests(TestCase):
         resp = self.client.get(reverse("story_detail", args=[story.id]))
         self.assertContains(resp, "<img")
 
+    def test_list_shows_image(self):
+        story = Story.objects.create(author=self.user, is_published=True)
+        story.texts.create(language="en", title="T", text="x")
+        story.images.create(image=ContentFile(b"im", "c.png"), thumbnail=ContentFile(b"im", "c.png"))
+
+        resp = self.client.get(reverse("story_list"))
+        self.assertContains(resp, "<img")
+
 
 class ImageCreationFlowTests(TestCase):
     def setUp(self):

--- a/taletinker/stories/views.py
+++ b/taletinker/stories/views.py
@@ -10,7 +10,7 @@ def story_list(request):
 
     stories = (
         Story.objects.filter(is_published=True)
-        .prefetch_related("texts", "author")
+        .prefetch_related("texts", "author", "images")
         .order_by("-created_at")
     )
 


### PR DESCRIPTION
## Summary
- show stories on the list page as Bootstrap cards with image thumbnails
- prefetch images for efficiency
- test that list view shows story images

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_b_685551f43360832883a27ddb1c47c220