### PR TITLE
Improve story list card info

### DIFF
--- a/taletinker/stories/models.py
+++ b/taletinker/stories/models.py
@@ -31,6 +31,11 @@ class Story(models.Model):
     def __str__(self):
         return f"Story by {self.author} @{self.created_at} in {self.original_language}"
 
+    @property
+    def languages(self) -> list[str]:
+        """Return list of language codes available for this story."""
+        return list(self.texts.values_list("language", flat=True))
+
 
 class StoryText(models.Model):
     story = models.ForeignKey(Story, on_delete=models.CASCADE, related_name="texts")

--- a/taletinker/stories/templates/stories/story_list.html
+++ b/taletinker/stories/templates/stories/story_list.html
@@ -3,13 +3,15 @@
 {% block content %}
 <h2>Stories</h2>
 {% if stories %}
-<div class="row row-cols-1 row-cols-md-3 g-4">
+<div class="row row-cols-1 row-cols-md-4 g-4">
   {% for story in stories %}
   <div class="col">
     <div class="card h-100">
       {% with img=story.images.first %}
         {% if img %}
-          <img src="{{ img.thumbnail.url }}" class="card-img-top" alt="Cover image" />
+          <a href="{% url 'story_detail' story.id %}">
+            <img src="{{ img.thumbnail.url }}" class="card-img-top" alt="Cover image" />
+          </a>
         {% endif %}
       {% endwith %}
       <div class="card-body">
@@ -21,8 +23,17 @@
           {% else %}
             by {{ story.author.username }}
           {% endif %}
+          {{ story.created_at|timesince }} ago
           </small>
         </p>
+        <p class="card-text">
+          <small class="text-muted">Languages: {{ story.languages|join:", " }}</small>
+        </p>
+        {% if story.audios.first %}
+          <audio controls class="w-100">
+            <source src="{{ story.audios.first.mp3.url }}" type="audio/mpeg" />
+          </audio>
+        {% endif %}
       </div>
       <div class="card-footer d-flex justify-content-between align-items-center">
         <span class="like-btn" data-story-id="{{ story.id }}">{% if user.is_authenticated and user in story.liked_by.all %}★{% else %}☆{% endif %}</span>

--- a/taletinker/stories/tests.py
+++ b/taletinker/stories/tests.py
@@ -292,3 +292,13 @@ class StoryAudioDisplayTests(TestCase):
         resp = self.client.get(reverse("story_detail", args=[story.id]))
         self.assertContains(resp, "<audio")
 
+    def test_list_shows_audio_and_languages(self):
+        story = Story.objects.create(author=self.user, is_published=True)
+        story.texts.create(language="en", title="T", text="x")
+        story.texts.create(language="es", title="T", text="y")
+        story.audios.create(mp3=ContentFile(b"mp3", name="a.mp3"), language="en")
+
+        resp = self.client.get(reverse("story_list"))
+        self.assertContains(resp, "<audio")
+        self.assertContains(resp, "Languages: en, es")
+


### PR DESCRIPTION
## Summary
- add `languages` property to story model
- show story timestamps, languages, cover links and audio on list view
- test audio and language display on list view

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_b_685559fcddac832891af9d6f18d5b07f