### PR TITLE
Fix playlist playback triggers

### DIFF
--- a/taletinker/stories/templates/stories/playlist_play.html
+++ b/taletinker/stories/templates/stories/playlist_play.html
@@ -5,6 +5,8 @@
   document.addEventListener('DOMContentLoaded', () => {
     const items = Array.from(document.querySelectorAll('.playlist-item'));
     const player = document.getElementById('playlist-player');
+    const summaryEl = document.getElementById('playlist-summary');
+    const durations = Array(items.length).fill(0);
     let index = 0;
 
     function formatTime(sec) {
@@ -26,9 +28,13 @@
       if (metaAudio) {
         metaAudio.addEventListener('loadedmetadata', () => {
           const dur = metaAudio.duration;
+          durations[idx] = isNaN(dur) ? 0 : dur;
           const span = item.querySelector('.duration');
           if (span && !isNaN(dur)) span.textContent = formatTime(dur);
+          updateSummary();
         });
+      } else {
+        updateSummary();
       }
       item.addEventListener('click', () => {
         index = idx;
@@ -36,6 +42,13 @@
         player.play();
       });
     });
+
+    function updateSummary() {
+      const total = durations.reduce((a, b) => a + b, 0);
+      if (summaryEl) {
+        summaryEl.textContent = `${items.length} stories \u2013 ${formatTime(total)}`;
+      }
+    }
 
     player.addEventListener('ended', () => {
       if (index + 1 < items.length) {
@@ -49,19 +62,20 @@
 
     if (items.length) {
       setActive(0);
-      player.addEventListener('loadedmetadata', () => player.play(), { once: true });
+      updateSummary();
     }
   });
 </script>
 {% endblock %}
 {% block content %}
 <h2 class="mb-3">My Playlist</h2>
+<p id="playlist-summary" class="small text-muted"></p>
 <ul class="list-group mb-3" id="playlist">
   {% for story in stories %}
     {% with audio=story.audios.first %}
     <li class="list-group-item playlist-item" {% if audio %}data-url="{{ audio.mp3.url }}"{% endif %}>
       <div class="d-flex justify-content-between align-items-center">
-        <a href="{% url 'story_detail' story.id %}">{{ story.texts.first.title }}</a>
+        <span>{{ story.texts.first.title }}</span>
         {% if audio %}
           <span class="duration small text-muted"></span>
           <audio preload="metadata" class="metadata-audio d-none">

--- a/taletinker/stories/templates/stories/story_list.html
+++ b/taletinker/stories/templates/stories/story_list.html
@@ -14,6 +14,8 @@
   document.addEventListener('DOMContentLoaded', () => {
     const items = Array.from(document.querySelectorAll('#playlist-panel .playlist-item'));
     const player = document.getElementById('playlist-player');
+    const summaryEl = document.getElementById('playlist-summary');
+    const durations = Array(items.length).fill(0);
     let index = 0;
 
     function formatTime(sec) {
@@ -35,9 +37,13 @@
       if (metaAudio) {
         metaAudio.addEventListener('loadedmetadata', () => {
           const dur = metaAudio.duration;
+          durations[idx] = isNaN(dur) ? 0 : dur;
           const span = item.querySelector('.duration');
           if (span && !isNaN(dur)) span.textContent = formatTime(dur);
+          updateSummary();
         });
+      } else {
+        updateSummary();
       }
       item.addEventListener('click', () => {
         index = idx;
@@ -45,6 +51,13 @@
         player.play();
       });
     });
+
+    function updateSummary() {
+      const total = durations.reduce((a, b) => a + b, 0);
+      if (summaryEl) {
+        summaryEl.textContent = `${items.length} stories \u2013 ${formatTime(total)}`;
+      }
+    }
 
     player.addEventListener('ended', () => {
       if (index + 1 < items.length) {
@@ -58,7 +71,7 @@
 
     if (items.length) {
       setActive(0);
-      player.addEventListener('loadedmetadata', () => player.play(), { once: true });
+      updateSummary();
     }
   });
 </script>
@@ -171,11 +184,12 @@
     {% if user.is_authenticated %}
     <div id="playlist-panel" class="bg-light border p-3 rounded">
       <h5>My Playlist</h5>
+      <p id="playlist-summary" class="small text-muted mb-1"></p>
       <ul class="list-group mb-3" id="playlist">
         {% for item in playlist.stories.all %}
           {% with audio=item.audios.first %}
           <li class="list-group-item d-flex justify-content-between align-items-center playlist-item" {% if audio %}data-url="{{ audio.mp3.url }}"{% endif %}>
-            <a href="{% url 'story_detail' item.id %}" class="text-decoration-none">{{ item.texts.first.title }}</a>
+            <span class="text-decoration-none">{{ item.texts.first.title }}</span>
             <div class="d-flex align-items-center">
               {% if audio %}
                 <span class="duration small text-muted me-2"></span>


### PR DESCRIPTION
## Summary
- prevent automatic playback on page load
- disable playlist item navigation
- show playlist total time and count

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6856ed7ab21c8328a87e8b2cd9215eb8