### PR TITLE
Fix slider layout and labels

### DIFF
--- a/taletinker/stories/forms.py
+++ b/taletinker/stories/forms.py
@@ -25,22 +25,34 @@ LENGTH_CHOICES = [
 
 
 class StoryCreationForm(forms.Form):
+    LABELS = "realistic,moderately realistic,balanced,moderately fantastic,fantastic"
+
     realism = forms.IntegerField(
-        min_value=0,
-        max_value=100,
-        initial=50,
+        min_value=1,
+        max_value=5,
+        initial=3,
         widget=forms.NumberInput(
-            attrs={"type": "range", "class": "form-range range-bubble"}
+            attrs={
+                "type": "range",
+                "class": "form-range range-bubble",
+                "step": 1,
+                "data-labels": LABELS,
+            }
         ),
         label="Realistic ↔ Fantastic",
     )
 
     didactic = forms.IntegerField(
-        min_value=0,
-        max_value=100,
-        initial=50,
+        min_value=1,
+        max_value=5,
+        initial=3,
         widget=forms.NumberInput(
-            attrs={"type": "range", "class": "form-range range-bubble"}
+            attrs={
+                "type": "range",
+                "class": "form-range range-bubble",
+                "step": 1,
+                "data-labels": LABELS,
+            }
         ),
         label="Didactic ↔ Fun",
     )

--- a/taletinker/stories/templates/stories/create_story.html
+++ b/taletinker/stories/templates/stories/create_story.html
@@ -9,7 +9,13 @@
   .chip input { display: none; }
   .chip.selected { background-color: #ddd; }
   .examples button { margin-right: 0.5rem; }
-  .range-bubble-wrapper { position: relative; }
+  .range-bubble-wrapper {
+    position: relative;
+    width: 100%;
+  }
+  .range-bubble-wrapper input[type=range] {
+    width: 100%;
+  }
   .range-bubble {
     position: absolute;
     top: -1.5rem;
@@ -47,9 +53,12 @@ window.addEventListener('DOMContentLoaded', () => {
     const bubble = document.createElement('span');
     bubble.className = 'range-bubble';
     wrapper.appendChild(bubble);
+    const labels = input.dataset.labels
+      ? input.dataset.labels.split(',').map(l => l.trim())
+      : null;
     const update = () => {
       const val = (input.value - input.min) / (input.max - input.min);
-      bubble.textContent = input.value;
+      bubble.textContent = labels ? labels[input.value - input.min] : input.value;
       bubble.style.left = `calc(${val * 100}% + (${8 - val * 16}px))`;
     };
     input.addEventListener('input', update);
@@ -110,14 +119,22 @@ window.addEventListener('DOMContentLoaded', () => {
     {{ form.realism.label_tag }}
     {{ form.realism }}
     <div class="d-flex justify-content-between small text-muted px-1">
-      <span>Realistic</span><span>Fantastic</span>
+      <span>realistic</span>
+      <span>moderately realistic</span>
+      <span>balanced</span>
+      <span>moderately fantastic</span>
+      <span>fantastic</span>
     </div>
   </div>
   <div class="mb-3">
     {{ form.didactic.label_tag }}
     {{ form.didactic }}
     <div class="d-flex justify-content-between small text-muted px-1">
-      <span>Didactic</span><span>Fun</span>
+      <span>realistic</span>
+      <span>moderately realistic</span>
+      <span>balanced</span>
+      <span>moderately fantastic</span>
+      <span>fantastic</span>
     </div>
   </div>
   <div class="mb-3">

--- a/taletinker/stories/tests.py
+++ b/taletinker/stories/tests.py
@@ -23,8 +23,8 @@ class CreateStoryViewTests(TestCase):
     def test_post_creates_story(self):
         self.client.force_login(self.user)
         data = {
-            "realism": 50,
-            "didactic": 50,
+            "realism": 3,
+            "didactic": 3,
             "age": 5,
             "themes": ["family"],
             "purposes": ["joyful"],
@@ -40,15 +40,15 @@ class CreateStoryViewTests(TestCase):
         self.assertEqual(Story.objects.count(), 1)
         story = Story.objects.first()
         self.assertEqual(story.author, self.user)
-        self.assertEqual(story.parameters["realism"], 50)
+        self.assertEqual(story.parameters["realism"], 3)
         self.assertEqual(story.texts.first().text, "Once upon a time")
         self.assertEqual(story.texts.first().title, "My Story")
 
     def test_post_redirects_to_detail(self):
         self.client.force_login(self.user)
         data = {
-            "realism": 50,
-            "didactic": 50,
+            "realism": 3,
+            "didactic": 3,
             "age": 5,
             "themes": ["family"],
             "purposes": ["joyful"],
@@ -82,8 +82,8 @@ class NinjaCreateApiTests(TestCase):
         response = self.client.post(
             "/api/create",
             {
-                "realism": 50,
-                "didactic": 50,
+                "realism": 3,
+                "didactic": 3,
                 "age": 5,
                 "story_length": "short",
             },
@@ -357,8 +357,8 @@ class ImageCreationFlowTests(TestCase):
     def test_detail_shows_creation_message_after_story_post(self):
         self.client.force_login(self.user)
         data = {
-            "realism": 50,
-            "didactic": 50,
+            "realism": 3,
+            "didactic": 3,
             "age": 5,
             "themes": ["family"],
             "purposes": ["joyful"],


### PR DESCRIPTION
## Summary
- maintain slider width so controls stay centered
- convert Realistic/Fantastic and Didactic/Fun scales to 1–5 with text labels
- adjust slider bubble script to show labels
- update tests for new scale

## Testing
- `pytest taletinker/stories/tests.py -q` *(fails: ImproperlyConfigured)*
- `pytest taletinker/accounts/tests.py -q` *(fails: ImproperlyConfigured)*

------
https://chatgpt.com/codex/tasks/task_b_6856fe1650dc832899babbf09e5f4582