### PR TITLE
Fix duplicate audio creation

### DIFF
--- a/taletinker/api.py
+++ b/taletinker/api.py
@@ -210,6 +210,9 @@ def create_audio(request, payload: AudioPayload):
     if not text_obj:
         return api.create_response(request, {"detail": "no story text"}, status=400)
 
+    if story.audios.filter(language=text_obj.language).exists():
+        return api.create_response(request, {"detail": "exists"}, status=400)
+
     client = openai.OpenAI()
 
     try:

--- a/taletinker/stories/tests.py
+++ b/taletinker/stories/tests.py
@@ -326,6 +326,17 @@ class CreateAudioApiTests(TestCase):
             input="#S\nhola",
         )
 
+    def test_audio_already_exists(self):
+        self.story.audios.create(mp3=ContentFile(b"mp3", name="a.mp3"), language="en")
+        self.client.force_login(self.user)
+        resp = self.client.post(
+            "/api/create_audio",
+            {"story_id": self.story.id},
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 400)
+        self.assertJSONEqual(resp.content, {"detail": "exists"})
+
 
 class StoryImageDisplayTests(TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary
- prevent duplicate StoryAudio per language
- add regression test for duplicate audio

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_b_68571318fb30832890a677f980d84745