### PR TITLE
Show supported languages on detail page

### DIFF
--- a/taletinker/stories/templates/stories/story_detail.html
+++ b/taletinker/stories/templates/stories/story_detail.html
@@ -21,7 +21,7 @@
 
 <p><strong>Languages:</strong>
   {% for lang in languages %}
-    <a href="?lang={{ lang }}">{{ lang }}</a>{% if not forloop.last %}, {% endif %}
+    <a href="?lang={{ lang }}"{% if lang == selected_language %} class="fw-bold"{% endif %}>{{ lang }}</a>{% if not forloop.last %}, {% endif %}
   {% endfor %}
 </p>
 
@@ -98,7 +98,20 @@
       </script>
     {% endif %}
 
-    <p>{{ text.text|linebreaks }}</p>
+    {% if text %}
+      <p>{{ text.text|linebreaks }}</p>
+    {% else %}
+      <p id="text-status">Creating text...</p>
+      <script>
+        document.addEventListener('DOMContentLoaded', () => {
+          fetch('/api/translate', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ story_id: {{ story.id }}, language: '{{ selected_language }}' })
+          }).then(resp => { if (resp.ok) location.reload(); });
+        });
+      </script>
+    {% endif %}
 
 </div>
 

--- a/taletinker/stories/views.py
+++ b/taletinker/stories/views.py
@@ -102,13 +102,14 @@ def story_detail(request, story_id: int):
     text_obj = None
     if lang:
         text_obj = story.texts.filter(language=lang).first()
-    if not text_obj:
+    else:
         text_obj = story.texts.first()
         lang = text_obj.language if text_obj else None
 
     audio_obj = story.audios.filter(language=lang).first() if lang else None
 
     available_langs = story.languages
+    supported_langs = [code for code, _ in settings.LANGUAGES]
     new_language_choices = [
         (code, label)
         for code, label in settings.LANGUAGES
@@ -119,7 +120,7 @@ def story_detail(request, story_id: int):
         "story": story,
         "text": text_obj,
         "audio": audio_obj,
-        "languages": available_langs,
+        "languages": supported_langs,
         "selected_language": lang,
         "new_language_choices": new_language_choices,
     }


### PR DESCRIPTION
## Summary
- show all LANGUAGES on story detail view
- generate missing translations on demand
- adapt tests for new audio params and language list

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_b_6857ad9163b48328ae878427aa460ffa