### PR TITLE
Fix audio selection for language

### DIFF
--- a/taletinker/stories/views.py
+++ b/taletinker/stories/views.py
@@ -56,12 +56,14 @@ def story_list(request):
     selected_language = request.GET.get("language")
 
     for story in stories:
-        lang = selected_language or (story.texts.first().language if story.texts.exists() else None)
+        lang = selected_language or (
+            story.texts.first().language if story.texts.exists() else None
+        )
         story.display_language = lang
         if lang:
             story.display_audio = story.audios.filter(language=lang).first()
         else:
-            story.display_audio = story.audios.first()
+            story.display_audio = None
 
     playlist = None
     if request.user.is_authenticated:
@@ -70,12 +72,14 @@ def story_list(request):
             playlist.stories.prefetch_related("audios", "texts")
         )
         for item in playlist_stories:
-            lang = selected_language or (item.texts.first().language if item.texts.exists() else None)
+            lang = selected_language or (
+                item.texts.first().language if item.texts.exists() else None
+            )
             item.display_language = lang
             if lang:
                 item.display_audio = item.audios.filter(language=lang).first()
             else:
-                item.display_audio = item.audios.first()
+                item.display_audio = None
     else:
         playlist_stories = []
 


### PR DESCRIPTION
## Summary
- prevent falling back to an arbitrary audio when browsing stories
- return `None` for `display_audio` if the chosen language isn't available

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_b_6857dc1c73188328b0fca2f4b73c0718