### PR TITLE
Fix audio file naming and response

### DIFF
--- a/taletinker/api.py
+++ b/taletinker/api.py
@@ -262,8 +262,9 @@ def create_audio(request, payload: AudioPayload):
             audio_data = b"".join(response.iter_bytes())
 
         story_audio = StoryAudio(story=story, language=target_language)
-        story_audio.mp3.save(f"speech{story.pk}.mp3", ContentFile(audio_data))
-        return {"audio_id": story_audio.id}
+        filename = f"speech{story.pk}_{target_language}.mp3"
+        story_audio.mp3.save(filename, ContentFile(audio_data))
+        return {"audio_id": story_audio.id, "file": story_audio.mp3.name}
     except openai.OpenAIError as exc:
         logger.exception("OpenAI API error")
         return api.create_response(request, {"detail": str(exc)}, status=503)

--- a/taletinker/stories/templates/stories/story_detail.html
+++ b/taletinker/stories/templates/stories/story_detail.html
@@ -119,7 +119,7 @@
                 const audio = document.createElement('audio');
                 audio.controls = true;
                 const source = document.createElement('source');
-                source.src = '/media/audio/speech{{ story.id }}.mp3?' + Date.now();
+                source.src = '/media/' + data.file + '?' + Date.now();
                 source.type = 'audio/mpeg';
                 audio.appendChild(source);
                 container.appendChild(audio);

--- a/taletinker/stories/templates/stories/story_list.html
+++ b/taletinker/stories/templates/stories/story_list.html
@@ -92,6 +92,7 @@
         body: JSON.stringify({ story_id: storyId, language: language })
       }).then(async resp => {
         if (resp.ok) {
+          const data = await resp.json();
           const container = document.createElement('div');
           container.id = 'audio-container-' + storyId;
           container.className = 'mt-auto';
@@ -99,7 +100,7 @@
           audio.controls = true;
           audio.className = 'w-100';
           const source = document.createElement('source');
-          source.src = '/media/audio/speech' + storyId + '.mp3?' + Date.now();
+          source.src = '/media/' + data.file + '?' + Date.now();
           source.type = 'audio/mpeg';
           audio.appendChild(source);
           container.appendChild(audio);

--- a/taletinker/stories/tests.py
+++ b/taletinker/stories/tests.py
@@ -288,6 +288,11 @@ class CreateAudioApiTests(TestCase):
         )
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(self.story.audios.count(), 1)
+        data = resp.json()
+        self.assertIn("audio_id", data)
+        self.assertIn("file", data)
+        self.assertIn(f"speech{self.story.id}_en", data["file"])
+        self.assertIn(f"speech{self.story.id}_en", self.story.audios.first().mp3.name)
 
     @patch("taletinker.api.openai.OpenAI")
     def test_generate_audio_specific_language(self, mock_openai):
@@ -321,6 +326,10 @@ class CreateAudioApiTests(TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(self.story.audios.count(), 1)
         self.assertEqual(self.story.audios.first().language, "es")
+        data = resp.json()
+        self.assertIn("file", data)
+        self.assertIn(f"speech{self.story.id}_es", data["file"])
+        self.assertIn(f"speech{self.story.id}_es", self.story.audios.first().mp3.name)
         create_mock.assert_called_with(
             model="tts-1",
             voice="shimmer",
@@ -375,6 +384,10 @@ class CreateAudioApiTests(TestCase):
         )
 
         self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertIn("file", data)
+        self.assertIn(f"speech{self.story.id}_es", data["file"])
+        self.assertIn(f"speech{self.story.id}_es", self.story.audios.first().mp3.name)
         # translation should have been saved
         self.assertEqual(self.story.texts.filter(language="es").count(), 1)
         self.assertEqual(self.story.audios.filter(language="es").count(), 1)


### PR DESCRIPTION
## Summary
- include language code in saved audio filename
- return filename from `/api/create_audio`
- update templates to use returned filename
- test new filename logic

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_b_6857f94ed26483288ba4165975bf7bdc