### PR TITLE
Fix login email error display

### DIFF
--- a/taletinker/templates/registration/login_email.html
+++ b/taletinker/templates/registration/login_email.html
@@ -8,10 +8,17 @@
   <div class="mb-3">
     {{ form.email.label_tag }}
     {{ form.email }}
+    {% if form.email.errors %}
+      <div class="text-danger small">{{ form.email.errors|join:" " }}</div>
+    {% endif %}
   </div>
   <div class="mb-3">
     {{ form.captcha }}
+    {% if form.captcha.errors %}
+      <div class="text-danger small">{{ form.captcha.errors|join:" " }}</div>
+    {% endif %}
   </div>
   <button type="submit" class="btn btn-primary">Send Login Link</button>
 </form>
+<p class="mt-3">Not registered? <a href="{% url 'signup' %}">Sign Up</a></p>
 {% endblock %}


### PR DESCRIPTION
## Summary
- show validation errors when logging in via email
- prompt sign up link for new users

## Testing
- `pytest -q` *(fails: no tests collected)*

------
https://chatgpt.com/codex/tasks/task_b_685924090410832881653fbeeaa94ad4