### PR TITLE
Fix login redirects and playlist details

### DIFF
--- a/taletinker/settings.py
+++ b/taletinker/settings.py
@@ -186,7 +186,7 @@ AUTH_USER_MODEL = "accounts.User"
 
 # Auth settings
 LOGIN_URL = "login"
-LOGIN_REDIRECT_URL = "create_story"
+LOGIN_REDIRECT_URL = "story_list"
 LOGOUT_REDIRECT_URL = "login"
 
 # Email login

--- a/taletinker/stories/admin.py
+++ b/taletinker/stories/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 
-from .models import Story, StoryAudio, StoryImage, StoryText
+from .models import Story, StoryAudio, StoryImage, StoryText, Playlist
 
 
 @admin.register(Story)
@@ -39,3 +39,9 @@ class StoryAudioAdmin(admin.ModelAdmin):
         "language",
         "created_at",
     ]
+
+
+@admin.register(Playlist)
+class PlaylistAdmin(admin.ModelAdmin):
+    list_display = ["user"]
+    filter_horizontal = ["stories"]

--- a/taletinker/stories/templates/stories/playlist_play.html
+++ b/taletinker/stories/templates/stories/playlist_play.html
@@ -60,16 +60,16 @@
       }
     });
 
+    updateSummary();
     if (items.length) {
       setActive(0);
-      updateSummary();
     }
   });
 </script>
 {% endblock %}
 {% block content %}
 <h2 class="mb-3">My Playlist</h2>
-<p id="playlist-summary" class="small text-muted"></p>
+<p id="playlist-summary" class="small text-muted">0 stories – 0:00</p>
 <ul class="list-group mb-3" id="playlist">
   {% for story in stories %}
     {% with audio=story.audios.first %}

--- a/taletinker/stories/templates/stories/story_list.html
+++ b/taletinker/stories/templates/stories/story_list.html
@@ -122,9 +122,9 @@
       }
     });
 
+    updateSummary();
     if (items.length) {
       setActive(0);
-      updateSummary();
     }
 
     initAudioGeneration(document);
@@ -219,7 +219,7 @@
 
         <div class="d-flex justify-content-between align-items-center mb-3">
           <h5 class="mb-0">My Playlist</h5>
-          <p id="playlist-summary" class="small text-muted mb-0">3 songs, 10 min</p>
+          <p id="playlist-summary" class="small text-muted mb-0">0 stories – 0:00</p>
         </div>
 
       <ul class="list-group mb-3" id="playlist">

--- a/taletinker/templates/registration/login_email.html
+++ b/taletinker/templates/registration/login_email.html
@@ -18,6 +18,9 @@
       <div class="text-danger small">{{ form.captcha.errors|join:" " }}</div>
     {% endif %}
   </div>
+  {% if next %}
+    <input type="hidden" name="next" value="{{ next }}" />
+  {% endif %}
   <button type="submit" class="btn btn-primary">Send Login Link</button>
 </form>
 <p class="mt-3">Not registered? <a href="{% url 'signup' %}">Sign Up</a></p>

--- a/taletinker/templates/registration/signup.html
+++ b/taletinker/templates/registration/signup.html
@@ -16,6 +16,9 @@
   <div class="mb-3">
     {{ form.captcha }}
   </div>
+  {% if next %}
+    <input type="hidden" name="next" value="{{ next }}" />
+  {% endif %}
   <button type="submit" class="btn btn-primary">Sign Up</button>
 </form>
 {% endblock %}

--- a/taletinker/urls.py
+++ b/taletinker/urls.py
@@ -37,7 +37,7 @@ urlpatterns = [
     path('admin/', admin.site.urls),
     path('signup/', SignupView.as_view(), name='signup'),
     path('login/', EmailLoginView.as_view(), name='login'),
-    path('login/token/', SesameLoginView.as_view(next_page="create_story"), name='login_token'),
+    path('login/token/', SesameLoginView.as_view(), name='login_token'),
     path('logout/', LogoutView.as_view(), name='logout'),
     path('create/', create_story, name='create_story'),
     path('story/<int:story_id>/', story_detail, name='story_detail'),


### PR DESCRIPTION
## Summary
- route login tokens to next page or home
- keep `next` parameter when emailing login links
- register playlists with Django admin
- update playlist summary defaults and initialization

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68592e4434f88328a57f0f8492a23c0d