### PR TITLE
Enable playlist drag-drop ordering

### DIFF
--- a/taletinker/stories/migrations/0004_playlist_order.py
+++ b/taletinker/stories/migrations/0004_playlist_order.py
@@ -1,0 +1,14 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('stories', '0003_playlist'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='playlist',
+            name='order',
+            field=models.JSONField(blank=True, default=list),
+        ),
+    ]

--- a/taletinker/stories/models.py
+++ b/taletinker/stories/models.py
@@ -84,6 +84,16 @@ class Playlist(models.Model):
         related_name="playlist",
     )
     stories = models.ManyToManyField(Story, related_name="playlists", blank=True)
+    order = models.JSONField(default=list, blank=True)
 
     def __str__(self):  # pragma: no cover - trivial
         return f"{self.user}'s playlist"
+
+    def ordered_stories(self):
+        """Return stories ordered by the stored order list."""
+        qs = list(self.stories.all())
+        if not self.order:
+            return qs
+        ordering = {sid: idx for idx, sid in enumerate(self.order)}
+        qs.sort(key=lambda s: ordering.get(s.id, len(ordering)))
+        return qs

--- a/taletinker/stories/templates/stories/story_list.html
+++ b/taletinker/stories/templates/stories/story_list.html
@@ -69,6 +69,7 @@
     const player = document.getElementById('playlist-player');
     const summaryEl = document.getElementById('playlist-summary');
     const durations = Array(items.length).fill(0);
+    const durationMap = {};
     let index = 0;
 
     function formatTime(sec) {
@@ -91,6 +92,7 @@
         metaAudio.addEventListener('loadedmetadata', () => {
           const dur = metaAudio.duration;
           durations[idx] = isNaN(dur) ? 0 : dur;
+          durationMap[item.dataset.storyId] = durations[idx];
           const span = item.querySelector('.duration');
           if (span && !isNaN(dur)) span.textContent = formatTime(dur);
           updateSummary();
@@ -126,6 +128,36 @@
     if (items.length) {
       setActive(0);
     }
+
+    items.forEach(item => {
+      item.draggable = true;
+      item.addEventListener('dragstart', () => {
+        item.classList.add('opacity-50');
+      });
+      item.addEventListener('dragend', () => {
+        item.classList.remove('opacity-50');
+      });
+    });
+
+    const listEl = document.getElementById('playlist');
+    listEl.addEventListener('dragover', e => {
+      e.preventDefault();
+      const dragging = document.querySelector('.playlist-item.opacity-50');
+      const siblings = Array.from(listEl.querySelectorAll('.playlist-item:not(.opacity-50)'));
+      const next = siblings.find(el => e.clientY < el.getBoundingClientRect().top + el.offsetHeight / 2);
+      listEl.insertBefore(dragging, next);
+    });
+
+    listEl.addEventListener('drop', () => {
+      items = Array.from(listEl.querySelectorAll('.playlist-item'));
+      const order = items.map(el => el.dataset.storyId);
+      fetch('{% url "reorder_playlist" %}', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams(order.map(id => ['order', id]))
+      });
+      updateSummary();
+    });
 
     initAudioGeneration(document);
 

--- a/taletinker/stories/tests.py
+++ b/taletinker/stories/tests.py
@@ -561,3 +561,14 @@ class PlaylistTests(TestCase):
         resp = self.client.get(reverse("story_list"))
         self.assertContains(resp, "playlist-player")
 
+    def test_reorder_playlist(self):
+        s1 = self._create_story("A")
+        s2 = self._create_story("B")
+        s3 = self._create_story("C")
+        for s in (s1, s2, s3):
+            self.client.post(reverse("add_to_playlist", args=[s.id]))
+        resp = self.client.post(reverse("reorder_playlist"), {"order": [s3.id, s1.id, s2.id]})
+        self.assertEqual(resp.status_code, 200)
+        playlist_stories = list(self.user.playlist.ordered_stories())
+        self.assertEqual(playlist_stories, [s3, s1, s2])
+

--- a/taletinker/urls.py
+++ b/taletinker/urls.py
@@ -28,6 +28,7 @@ from taletinker.stories.views import (
     add_to_playlist,
     add_filtered_to_playlist,
     remove_from_playlist,
+    reorder_playlist,
     play_playlist,
 )
 from taletinker.accounts.views import LogoutView, SignupView, EmailLoginView
@@ -44,6 +45,7 @@ urlpatterns = [
     path('playlist/add/<int:story_id>/', add_to_playlist, name='add_to_playlist'),
     path('playlist/add_all/', add_filtered_to_playlist, name='add_filtered_to_playlist'),
     path('playlist/remove/<int:story_id>/', remove_from_playlist, name='remove_from_playlist'),
+    path('playlist/reorder/', reorder_playlist, name='reorder_playlist'),
     path('playlist/play/', play_playlist, name='play_playlist'),
     path('api/', ninja_api.urls),
     path('', story_list, name='story_list'),


### PR DESCRIPTION
## Summary
- add `order` field to Playlist model
- implement playlist ordering helpers
- support ordering in playlist views
- endpoint to reorder playlist
- drag-and-drop reorder UI on story list page
- migrations and tests for playlist ordering

## Testing
- `python manage.py test` *(fails: test_email_login_flow)*

------
https://chatgpt.com/codex/tasks/task_b_68593081f73083288ea8683a001eebd8