### PR TITLE
Fix playlist reorder persistence

### DIFF
--- a/taletinker/settings.py
+++ b/taletinker/settings.py
@@ -186,7 +186,7 @@ AUTH_USER_MODEL = "accounts.User"
 
 # Auth settings
 LOGIN_URL = "login"
-LOGIN_REDIRECT_URL = "story_list"
+LOGIN_REDIRECT_URL = "create_story"
 LOGOUT_REDIRECT_URL = "login"
 
 # Email login

--- a/taletinker/stories/templates/stories/story_list.html
+++ b/taletinker/stories/templates/stories/story_list.html
@@ -11,6 +11,10 @@
 </style>
 <script>
   document.addEventListener('DOMContentLoaded', () => {
+    function getCookie(name) {
+      const value = document.cookie.split('; ').find(row => row.startsWith(name + '='));
+      return value ? decodeURIComponent(value.split('=')[1]) : null;
+    }
     function initAudioGeneration(root = document) {
       root.querySelectorAll('[data-create-audio]').forEach(statusEl => {
         const storyId = statusEl.dataset.storyId;
@@ -65,7 +69,7 @@
         });
       });
     }
-    const items = Array.from(document.querySelectorAll('#playlist-panel .playlist-item'));
+    let items = Array.from(document.querySelectorAll('#playlist-panel .playlist-item'));
     const player = document.getElementById('playlist-player');
     const summaryEl = document.getElementById('playlist-summary');
     const durations = Array(items.length).fill(0);
@@ -153,7 +157,11 @@
       const order = items.map(el => el.dataset.storyId);
       fetch('{% url "reorder_playlist" %}', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        credentials: 'same-origin',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          'X-CSRFToken': getCookie('csrftoken')
+        },
         body: new URLSearchParams(order.map(id => ['order', id]))
       });
       updateSummary();


### PR DESCRIPTION
## Summary
- persist playlist order via CSRF token
- allow updating playlist items list
- redirect login to story creation page

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_b_68593e0ad3d08328a56ca5ef2ee8cc1d