### PR TITLE
Add language and RSS alternate links

### DIFF
--- a/taletinker/settings.py
+++ b/taletinker/settings.py
@@ -75,6 +75,7 @@ TEMPLATES = [
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
+                "django.template.context_processors.i18n",
             ],
         },
     },

--- a/taletinker/templates/base.html
+++ b/taletinker/templates/base.html
@@ -10,6 +10,11 @@
           integrity="sha256-zRgmWB5PK4CvTx4FiXsxbHaYRBBjz/rvu97sOC7kzXI=" crossorigin="anonymous"
     >
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/font/bootstrap-icons.min.css">
+    <!-- Alternate language versions -->
+    {% for code, name in LANGUAGES %}
+    <link rel="alternate" hreflang="{{ code }}" href="{{ request.path }}?lang={{ code }}" />
+    <link rel="alternate" type="application/rss+xml" title="Latest stories in {{ name }}" href="{% url 'story_feed' code %}" />
+    {% endfor %}
 
     {% block extra_head %}{% endblock %}
 </head>


### PR DESCRIPTION
## Summary
- add alternate language hreflang links for supported translations
- reference language specific RSS feeds
- expose LANGUAGES in templates via the i18n context processor

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_685a7652ca248328abb024c1a9c21529