### PR TITLE
Implement basic title search

### DIFF
--- a/taletinker/stories/forms.py
+++ b/taletinker/stories/forms.py
@@ -131,3 +131,11 @@ class StoryFilterForm(forms.Form):
         widget=forms.Select(attrs={"class": "form-select"}),
         label="Sort By",
     )
+
+    search = forms.CharField(
+        required=False,
+        widget=forms.TextInput(
+            attrs={"class": "form-control", "placeholder": "Search"}
+        ),
+        label="Search",
+    )

--- a/taletinker/stories/templates/stories/story_list.html
+++ b/taletinker/stories/templates/stories/story_list.html
@@ -223,6 +223,10 @@
       </div>
 
       <div class="col-auto">
+        {{ form.search.label_tag }}{{ form.search }}
+      </div>
+
+      <div class="col-auto">
         <button type="submit" class="btn btn-secondary">Apply</button>
       </div>
     </form>

--- a/taletinker/stories/tests.py
+++ b/taletinker/stories/tests.py
@@ -206,6 +206,14 @@ class StoryListAndDetailTests(TestCase):
         self.assertContains(resp, "Hola")
         self.assertNotContains(resp, "Hello")
 
+    def test_search_by_title(self):
+        self._create_story(title="Red Apple", published=True)
+        self._create_story(title="Blue Banana", published=True)
+
+        resp = self.client.get(reverse("story_list") + "?search=red")
+        self.assertContains(resp, "Red Apple")
+        self.assertNotContains(resp, "Blue Banana")
+
     def test_sort_by_popularity(self):
         s1 = self._create_story(title="One", published=True)
         s2 = self._create_story(title="Two", published=True)

--- a/taletinker/stories/views.py
+++ b/taletinker/stories/views.py
@@ -28,11 +28,14 @@ def _filtered_stories(request):
         theme = form.cleaned_data.get("theme")
         language = form.cleaned_data.get("language")
         sort = form.cleaned_data.get("sort") or "newest"
+        search = form.cleaned_data.get("search")
 
         if age:
             stories = stories.filter(parameters__age=int(age))
         if language:
             stories = stories.filter(texts__language=language)
+        if search:
+            stories = stories.filter(texts__title__icontains=search).distinct()
 
         stories = stories.annotate(num_likes=Count("liked_by"))
         stories = stories.order_by("-created_at")


### PR DESCRIPTION
## Summary
- add a search field to `StoryFilterForm`
- filter stories by title with case-insensitive match
- expose search field in story list template
- test searching by title

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_b_685a9ad38b4483289ff7cddad2032323